### PR TITLE
Async error handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # flowery 0.0.1.9000
 
+* Generator arguments are forced on reentry in the approriate context
+  (e.g. in the `tryCatch()` context if generator was yielded from a
+  `tryCatch()`). This makes it possible to clean up cancelled
+  generators (by jumping from the generator with a restart) or
+  propagate errors in async functions.
+
 * Generators and async functions now support yielding within
   `tryCatch()` expressions.
 

--- a/R/async.R
+++ b/R/async.R
@@ -144,9 +144,23 @@ get_async_ops <- function(env) {
 
   async_ops(
     package = "promises",
-    then = function(x, callback) promises::then(x, onFulfilled = callback),
-    as_promise = function(x) if (promises::is.promise(x)) x else promises::promise_resolve(x)
+    then = op_then,
+    as_promise = op_as_promise
   )
+}
+op_then <- function(x, callback) {
+  promises::then(
+    x,
+    onFulfilled = callback,
+    onRejected = function(cnd) callback(stop(cnd))
+  )
+}
+op_as_promise <- function(x) {
+  if (promises::is.promise(x)) {
+    x
+  } else {
+    promises::promise_resolve(x)
+  }
 }
 
 #' Sleep asynchronously

--- a/R/parser.R
+++ b/R/parser.R
@@ -680,6 +680,16 @@ suspend_state <- function(expr,
     assign_state <- new_state(assign_block, NULL, counter())
     node_list_poke_cdr(states, assign_state)
     counter(inc = 1L)
+  } else if (!last) {
+    # Insert state to force the reentering generator argument in the
+    # proper context. This is how generators can be cancelled and cleaned up.
+    force_block <- expr({
+      without_call_errors(force(arg))
+      !!continue_call(continue(counter, last), machine_depth(counter))
+    })
+    force_state <- new_state(force_block, NULL, counter())
+    node_list_poke_cdr(states, force_state)
+    counter(inc = 1L)
   }
 
   states

--- a/R/step-reduce.R
+++ b/R/step-reduce.R
@@ -474,6 +474,8 @@ on_load(async_reduce_steps %<~% async(function(x, steps, builder, init) {
 }))
 
 on_load(async_reduce %<~% async(function(.x, .f, ...) {
+  out <- NULL
+
   while (TRUE) {
     new <- await(.x())
 

--- a/R/utils-promises.R
+++ b/R/utils-promises.R
@@ -23,11 +23,19 @@ prom_status <- function(prom) {
   impl <- prom_impl(prom)
   impl$status()
 }
+
+# FIXME: Is there a better way to dereference resolved promises?
 prom_value <- function(prom) {
-  # FIXME: Is there a better way to dereference resolved promises?
   impl <- prom_impl(prom)
-  .subset2(impl, ".__enclos_env__")$private$value
+  out <- .subset2(impl, ".__enclos_env__")$private$value
+
+  if (is_string(prom_status(prom), "rejected")) {
+    stop(out)
+  } else {
+    out
+  }
 }
+
 prom_impl <- function(prom) {
   stopifnot(promises::is.promise(prom))
   attr(prom, "promise_impl", exact = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,3 +66,10 @@ try_catch_arg <- function(call) {
 
   abort("Can't supply empty `tryCatch()`.")
 }
+
+without_call_errors <- function(expr, env = caller_env()) {
+  withCallingHandlers(expr, simpleError = function(cnd) {
+    cnd$call <- NULL
+    stop(cnd)
+  })
+}

--- a/tests/testthat/_snaps/async.md
+++ b/tests/testthat/_snaps/async.md
@@ -214,6 +214,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   if ({
                       if (is_null(arg)) {
                         FALSE
@@ -222,18 +225,18 @@
                         TRUE
                       }
                   }) {
-                      state[[2L]] <- 3L
+                      state[[2L]] <- 4L
                   } else {
                       break
                   }
-              }, `3` = {
+              }, `4` = {
                   user({
                       values <<- c(values, x)
                   })
                   iterators[[3L]] <- as_iterator(user(s2))
-                  state[[2L]] <- 4L
+                  state[[2L]] <- 5L
                   state[[3L]] <- 1L
-              }, `4` = {
+              }, `5` = {
                   repeat switch(state[[3L]], `1` = {
                       .last_value <- then(as_promise({
                         iterator <- iterators[[3L]]
@@ -243,6 +246,9 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 3L
+                  }, `3` = {
                       if ({
                         if (is_null(arg)) {
                           FALSE
@@ -251,11 +257,11 @@
                           TRUE
                         }
                       }) {
-                        state[[3L]] <- 3L
+                        state[[3L]] <- 4L
                       } else {
                         break
                       }
-                  }, `3` = {
+                  }, `4` = {
                       user({
                         values <<- c(values, y)
                       })

--- a/tests/testthat/_snaps/generator.md
+++ b/tests/testthat/_snaps/generator.md
@@ -59,6 +59,9 @@
                         suspend()
                         return(last_value())
                       }, `2` = {
+                        without_call_errors(force(arg))
+                        state[[3L]] <- 3L
+                      }, `3` = {
                         break
                       })
                       n <- length(state)

--- a/tests/testthat/_snaps/parser-block.md
+++ b/tests/testthat/_snaps/parser-block.md
@@ -45,6 +45,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "after1"
                   "after2"
@@ -76,6 +79,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "after"
               })
@@ -110,14 +116,20 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               validate_yield(user({
                   "during"
                   2L
               }))
-              state[[1L]] <- 3L
+              state[[1L]] <- 4L
               suspend()
               return(last_value())
-          }, `3` = {
+          }, `4` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 5L
+          }, `5` = {
               user({
                   "after"
               })
@@ -151,13 +163,19 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               validate_yield(user({
                   2L
               }))
-              state[[1L]] <- 3L
+              state[[1L]] <- 4L
               suspend()
               return(last_value())
-          }, `3` = {
+          }, `4` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 5L
+          }, `5` = {
               user({
                   "after"
               })
@@ -245,6 +263,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               validate_yield(user({
                   2L
               }))
@@ -285,6 +306,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "after-inner"
                   "after1"
@@ -323,6 +347,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "after-inner"
                   "after1"
@@ -360,6 +387,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "after1"
                   "after2"
@@ -402,20 +432,29 @@
               suspend()
               return(last_value())
           }, `2` = {
-              validate_yield(user({
-                  2L
-              }))
+              without_call_errors(force(arg))
               state[[1L]] <- 3L
-              suspend()
-              return(last_value())
           }, `3` = {
               validate_yield(user({
-                  3L
+                  2L
               }))
               state[[1L]] <- 4L
               suspend()
               return(last_value())
           }, `4` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 5L
+          }, `5` = {
+              validate_yield(user({
+                  3L
+              }))
+              state[[1L]] <- 6L
+              suspend()
+              return(last_value())
+          }, `6` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 7L
+          }, `7` = {
               user({
                   "after-inner"
                   "after"
@@ -452,6 +491,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "after-inner-inner"
                   "after"
@@ -488,6 +530,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "after-inner"
                   "after"

--- a/tests/testthat/_snaps/parser-if.md
+++ b/tests/testthat/_snaps/parser-if.md
@@ -39,11 +39,14 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "if-after"
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -146,11 +149,14 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "else-after"
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -220,12 +226,15 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "inner-after"
                       "if-after"
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -318,6 +327,9 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 3L
+                  }, `3` = {
                       break
                   })
                   n <- length(state)
@@ -545,11 +557,14 @@
                         suspend()
                         return(last_value())
                       }, `2` = {
+                        without_call_errors(force(arg))
+                        state[[4L]] <- 3L
+                      }, `3` = {
                         user({
                           "if-3-after"
                         })
-                        state[[4L]] <- 3L
-                      }, `3` = {
+                        state[[4L]] <- 4L
+                      }, `4` = {
                         break
                       })
                       n <- length(state)
@@ -665,12 +680,15 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "if-after"
                   })
                   exhausted <- TRUE
                   return(last_value())
-              }, `3` = {
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -693,12 +711,15 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "else-after"
                   })
                   exhausted <- TRUE
                   return(last_value())
-              }, `3` = {
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -761,11 +782,14 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "if-after"
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -788,11 +812,14 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "else-after"
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -854,6 +881,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   break
               })
               n <- length(state)
@@ -875,6 +905,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   break
               })
               n <- length(state)
@@ -937,11 +970,14 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "if-after"
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -963,6 +999,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   break
               })
               n <- length(state)
@@ -1025,6 +1064,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   break
               })
               n <- length(state)
@@ -1046,11 +1088,14 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "else-after"
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -1119,11 +1164,14 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 3L
+                  }, `3` = {
                       user({
                         "if-3-after"
                       })
-                      state[[3L]] <- 3L
-                  }, `3` = {
+                      state[[3L]] <- 4L
+                  }, `4` = {
                       break
                   })
                   n <- length(state)
@@ -1234,11 +1282,14 @@
                         suspend()
                         return(last_value())
                       }, `2` = {
+                        without_call_errors(force(arg))
+                        state[[4L]] <- 3L
+                      }, `3` = {
                         user({
                           "if-3-after"
                         })
-                        state[[4L]] <- 3L
-                      }, `3` = {
+                        state[[4L]] <- 4L
+                      }, `4` = {
                         break
                       })
                       n <- length(state)
@@ -1307,6 +1358,9 @@
                         suspend()
                         return(last_value())
                       }, `2` = {
+                        without_call_errors(force(arg))
+                        state[[4L]] <- 3L
+                      }, `3` = {
                         break
                       })
                       n <- length(state)

--- a/tests/testthat/_snaps/parser-loop.md
+++ b/tests/testthat/_snaps/parser-loop.md
@@ -32,6 +32,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "loop-after"
                   })
@@ -180,6 +183,9 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 3L
+                  }, `3` = {
                       break
                   })
                   n <- length(state)
@@ -307,6 +313,9 @@
               suspend()
               return(last_value())
           }, `4` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 5L
+          }, `5` = {
               user({
                   "after"
               })
@@ -393,6 +402,9 @@
               suspend()
               return(last_value())
           }, `4` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 5L
+          }, `5` = {
               user({
                   "after"
               })
@@ -479,20 +491,26 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "loop-after"
                       "next"
                   })
                   state[[2L]] <- 1L
-              }, `3` = {
+              }, `4` = {
                   validate_yield(user({
                       "next-after"
                       2L
                   }))
-                  state[[2L]] <- 4L
+                  state[[2L]] <- 5L
                   suspend()
                   return(last_value())
-              }, `4` = {
+              }, `5` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 6L
+              }, `6` = {
                   user({
                       "loop-final"
                   })
@@ -664,26 +682,32 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "loop-after"
                       "break"
                   })
                   break
-              }, `3` = {
+              }, `4` = {
                   user({
                       "break-after"
                       "next"
                   })
                   state[[2L]] <- 1L
-              }, `4` = {
+              }, `5` = {
                   validate_yield(user({
                       "next-after"
                       2L
                   }))
-                  state[[2L]] <- 5L
+                  state[[2L]] <- 6L
                   suspend()
                   return(last_value())
-              }, `5` = {
+              }, `6` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 7L
+              }, `7` = {
                   user({
                       "loop-final"
                   })
@@ -966,11 +990,14 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 3L
+                  }, `3` = {
                       user({
                         "after-pause"
                       })
-                      state[[3L]] <- 3L
-                  }, `3` = {
+                      state[[3L]] <- 4L
+                  }, `4` = {
                       break
                   })
                   n <- length(state)
@@ -1033,6 +1060,9 @@
                   suspend()
                   return(last_value())
               }, `3` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 4L
+              }, `4` = {
                   user({
                       "loop-after"
                   })
@@ -1080,6 +1110,9 @@
                   suspend()
                   return(last_value())
               }, `3` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 4L
+              }, `4` = {
                   user({
                       "loop-after"
                   })
@@ -1169,18 +1202,21 @@
                   suspend()
                   return(last_value())
               }, `3` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 4L
+              }, `4` = {
                   user({
                       "loop-after"
                   })
                   if (user({
                       TRUE
                   })) {
-                      state[[2L]] <- 4L
-                  } else {
                       state[[2L]] <- 5L
+                  } else {
+                      state[[2L]] <- 6L
                   }
                   state[[3L]] <- 1L
-              }, `4` = {
+              }, `5` = {
                   repeat switch(state[[3L]], `1` = {
                       user({
                         "break-before"
@@ -1205,8 +1241,8 @@
                       next
                   }
                   length(state) <- 2L
-                  state[[2L]] <- 6L
-              }, `5` = {
+                  state[[2L]] <- 7L
+              }, `6` = {
                   repeat switch(state[[3L]], `1` = {
                       validate_yield(user({
                         "yield-2-before"
@@ -1216,11 +1252,14 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 3L
+                  }, `3` = {
                       user({
                         "yield-2-after"
                       })
-                      state[[3L]] <- 3L
-                  }, `3` = {
+                      state[[3L]] <- 4L
+                  }, `4` = {
                       break
                   })
                   n <- length(state)
@@ -1232,14 +1271,14 @@
                       next
                   }
                   length(state) <- 2L
-                  state[[2L]] <- 6L
-              }, `6` = {
+                  state[[2L]] <- 7L
+              }, `7` = {
                   user({
                       "next-before"
                       "next"
                   })
                   state[[2L]] <- 1L
-              }, `7` = {
+              }, `8` = {
                   user({
                       "loop-end"
                   })
@@ -1431,6 +1470,9 @@
                   suspend()
                   return(last_value())
               }, `3` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 4L
+              }, `4` = {
                   user({
                       "for-after"
                   })
@@ -1505,6 +1547,9 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 3L
+                  }, `3` = {
                       break
                   })
                   n <- length(state)
@@ -1977,6 +2022,9 @@
                       suspend()
                       return(last_value())
                   }, `3` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 4L
+                  }, `4` = {
                       user({
                         "break"
                       })

--- a/tests/testthat/_snaps/parser.md
+++ b/tests/testthat/_snaps/parser.md
@@ -164,6 +164,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "bar"
               })
@@ -196,6 +199,9 @@
               suspend()
               return(last_value())
           }, `2` = {
+              without_call_errors(force(arg))
+              state[[1L]] <- 3L
+          }, `3` = {
               user({
                   "bar"
               })
@@ -269,6 +275,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       "break"
                   })
@@ -321,6 +330,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       body3()
                   })
@@ -453,6 +465,9 @@
                   suspend()
                   return(last_value())
               }, `3` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 4L
+              }, `4` = {
                   user({
                       body3()
                   })
@@ -770,6 +785,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   break
               })
               n <- length(state)
@@ -831,6 +849,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   break
               })
               n <- length(state)
@@ -852,6 +873,9 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   break
               })
               n <- length(state)
@@ -918,11 +942,14 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       then2()
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -945,11 +972,14 @@
                   suspend()
                   return(last_value())
               }, `2` = {
+                  without_call_errors(force(arg))
+                  state[[2L]] <- 3L
+              }, `3` = {
                   user({
                       else2()
                   })
-                  state[[2L]] <- 3L
-              }, `3` = {
+                  state[[2L]] <- 4L
+              }, `4` = {
                   break
               })
               n <- length(state)
@@ -1214,6 +1244,9 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[3L]] <- 3L
+                  }, `3` = {
                       break
                   })
                   n <- length(state)
@@ -1840,6 +1873,9 @@
                       suspend()
                       return(last_value())
                   }, `2` = {
+                      without_call_errors(force(arg))
+                      state[[2L]] <- 3L
+                  }, `3` = {
                       break
                   })
                   n <- length(state)

--- a/tests/testthat/test-async.R
+++ b/tests/testthat/test-async.R
@@ -173,3 +173,27 @@ test_that("yield() inside `async_generator()` returns a promise", {
   new_g <- async_generator(function() yield(1))
   expect_true(inherits(new_g()(), "promise"))
 })
+
+test_that("async functions handle errors", {
+  async_fail <- async(function() {
+    await(async_sleep(0))
+    stop("some error")
+  })
+  g <- async(function() {
+    await(async_fail())
+    "value"
+  })
+  expect_error(
+    wait_for(g()),
+    "some error"
+  )
+
+  g <- async(function() {
+    tryCatch(await(async_fail()), error = function(...) "handled")
+    "value"
+  })
+  expect_equal(
+    wait_for(g()),
+    "value"
+  )
+})

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -223,3 +223,21 @@ test_that("can't await() within a generator", {
   expect_error(generator(function() await(foo))(), "non-async")
   expect_error(generator(function() for (x in await_each(foo)) NULL)(), "non-async")
 })
+
+test_that("reentering the generator forces argument in proper context", {
+  g <- generator(function() {
+    yield("value")
+    "wrong"
+  })()
+  g()
+  expect_error(g(stop("error")), "error")
+
+  g <- generator(function() {
+    tryCatch(error = function(...) "handled", {
+      yield("value")
+      return("wrong")
+    })
+  })()
+  g()
+  expect_equal(g(stop("error")), "handled")
+})


### PR DESCRIPTION
* Force generator argument on reentry, in the right context (e.g. inside the `tryCatch()` context if any).

* Throw errors of rejected promises inside the internal async generator.